### PR TITLE
语句缺少分号

### DIFF
--- a/graphengine/ge/common/auth/file_saver.cc
+++ b/graphengine/ge/common/auth/file_saver.cc
@@ -205,7 +205,7 @@ Status FileSaver::SaveToBuffWithFileHeader(const ModelFileHeader &file_header,
   // save to buff
   auto buff = reinterpret_cast<uint8_t *>(malloc(total_size));
   GE_CHK_BOOL_RET_STATUS(buff != nullptr, FAILED, "Malloc failed!");
-  GE_PRINT_DYNAMIC_MEMORY(malloc, "File buffer.", total_size)
+  GE_PRINT_DYNAMIC_MEMORY(malloc, "File buffer.", total_size);
   model.data.reset(buff, [](uint8_t *buff) {
     GELOGD("Free online model memory.");
     free(buff);


### PR DESCRIPTION
执行npu环境源码编译时提示该处存在编译错误。